### PR TITLE
Favourites tab complete and functional with css

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -203,7 +203,8 @@
   background: #FFFFFF;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  width: 9%;
+  width: 180px;
+  height: 190px ;
   align-items: center;
 
 }
@@ -438,26 +439,26 @@
 
 /* Edit Category button */
 .buttons .edit-category {
-  background-color: #9F8772; /* Earthy brown */
+  background-color: #9F8772; 
   color: white;
   margin-right: 0.5rem;
   transition: all 0.3s ease;
 }
 
 .buttons .edit-category:hover {
-  background-color: #665A48; /* Darker brown */
+  background-color: #665A48; 
   transform: translateY(-2px);
 }
 
 /* Delete button */
 .buttons .delete-btn {
-  background-color: #d4a373; /* Light terracotta */
+  background-color: #d4a373; 
   color: white;
   transition: all 0.3s ease;
 }
 
 .buttons .delete-btn:hover {
-  background-color: #c08552; /* Darker terracotta */
+  background-color: #c08552; 
   transform: translateY(-2px);
 }
 
@@ -474,4 +475,191 @@
   outline: none;
   border-color: #665A48;
   box-shadow: 0 0 0 2px rgba(102, 90, 72, 0.2);
+}
+
+/* One Country Page Styles */
+.one-country-page {
+  margin: 1rem auto;
+  padding: 1rem;
+  background-color: #EDE4E0;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(102, 90, 72, 0.1);
+  font-family: 'Open Sans', sans-serif;
+  color: #665A48;
+}
+
+.country-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.country-header h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  color: #665A48;
+  margin-bottom: 1rem;
+}
+
+.country-flag {
+  width: 300px;
+  height: auto;
+  border: 3px solid #000000;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.country-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 0.5rem;
+  margin-top: 3rem;
+}
+
+.country-detail-item {
+  background-color: #f5f0ec;
+  padding: 1rem;
+  border-radius: 8px;
+  border-left: 4px solid #9F8772;
+}
+
+.country-detail-item p {
+  margin: 0.5rem 0;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.country-detail-item strong {
+  color: #665A48;
+  font-weight: 600;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin: 2rem 0;
+}
+
+.action-button {
+  padding: 0.8rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 600;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.favorite-button {
+  background-color: #9F8772;
+  color: #EDE4E0;
+}
+
+.favorite-button:hover {
+  background-color: #665A48;
+}
+
+.favorite-button.added {
+  background-color: #9dcf85; 
+}
+
+.review-button {
+  background-color: #C8DBBE;
+  color: #665A48;
+}
+
+.review-button:hover {
+  background-color: #9F8772;
+  color: #EDE4E0;
+}
+
+.reviews-section {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid #C8DBBE;
+}
+
+
+/* Favourites Page */
+.favourites-page {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  font-family: 'Open Sans', sans-serif;
+}
+
+.favourites-heading {
+  text-align: center;
+  color: #665A48;
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  margin-bottom: 2rem;
+}
+
+.no-favourites {
+  text-align: center;
+  color: #9F8772;
+  font-size: 1.2rem;
+}
+
+.favourites-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 2rem;
+  padding: 1rem;
+}
+
+.favourite-card {
+  background: #EDE4E0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.favourite-card:hover {
+  transform: translateY(-5px);
+}
+
+.country-link {
+  text-decoration: none;
+  color: #665A48;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-grow: 1;
+}
+
+.favourite-flag {
+  width: 120px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+  border: 1px solid #9F8772;
+  margin-bottom: 1rem;
+}
+
+.remove-btn {
+  background-color: #9F8772;
+  color: #EDE4E0;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 600;
+  margin-top: 1rem;
+  transition: all 0.3s ease;
+}
+
+.remove-btn:hover {
+  background-color: #665A48;
 }

--- a/src/pages/Favourite.jsx
+++ b/src/pages/Favourite.jsx
@@ -1,11 +1,57 @@
-// EDITH WRITE YOUR CODE IN THIS PAGE
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router";
+
 function Favourite() {
-    return (
-        <>
-            <h1>This is the favourite country page</h1>
-            <i>(EDITH WRITE YOUR CODE IN THIS PAGE)</i>
-        </>
-    )
+  const [favourites, setFavourites] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  // Load favourites from localStorage
+  useEffect(() => {
+    const savedFavourites = JSON.parse(localStorage.getItem("favourites")) || [];
+    setFavourites(savedFavourites);
+    setLoading(false);
+  }, []);
+
+  const removeFromFavourites = (countryName) => {
+    const updatedFavourites = favourites.filter(
+      (country) => country.name.common !== countryName
+    );
+    setFavourites(updatedFavourites);
+    localStorage.setItem("favourites", JSON.stringify(updatedFavourites));
+  };
+
+  if (loading) return <p>Loading favourites...</p>;
+
+  return (
+    <div className="favourites-page">
+      <h1 className="favourites-heading">Your Favourite Countries</h1>
+      
+      {favourites.length === 0 ? (
+        <p className="no-favourites">No favourites yet. Add some from country pages!</p>
+      ) : (
+        <div className="favourites-grid">
+          {favourites.map((country) => (
+            <div key={country.name.common} className="favourite-card">
+              <Link to={`/country/${country.name.common}`} className="country-link">
+                <img
+                  src={country.flags.png}
+                  alt={country.name.common}
+                  className="favourite-flag"
+                />
+                <h3>{country.name.common}</h3>
+              </Link>
+              <button
+                onClick={() => removeFromFavourites(country.name.common)}
+                className="remove-btn"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 export default Favourite;

--- a/src/pages/OneCountry.jsx
+++ b/src/pages/OneCountry.jsx
@@ -8,6 +8,8 @@ function OneCountry() {
   const [error, setError] = useState("");
   const [showReviews, setShowReviews] = useState(false);
   const [allCountries, setAllCountries] = useState([]);
+  const [isFavorite, setIsFavorite] = useState(false);
+
 
   // Normalizes names to compare
   const normalize = (str) =>
@@ -55,14 +57,25 @@ function OneCountry() {
       });
   }, [singleCountry, allCountries]);
 
+    useEffect(() => {
+    if (country) {
+      const favorites = JSON.parse(localStorage.getItem("favourites")) || [];
+      setIsFavorite(favorites.some(fav => fav.name.common === country.name.common));
+    }
+  }, [country]);
+
   const handleAddToFavourites = () => {
     let favourites = JSON.parse(localStorage.getItem("favourites")) || [];
-    if (!favourites.find((c) => c.name.common === country.name.common)) {
+    if (!isFavorite) {
       favourites.push(country);
       localStorage.setItem("favourites", JSON.stringify(favourites));
+      setIsFavorite(true);
       alert(`${country.name.common} added to favourites!`);
     } else {
-      alert(`${country.name.common} is already in favourites.`);
+      const updatedFavorites = favourites.filter(fav => fav.name.common !== country.name.common);
+      localStorage.setItem("favourites", JSON.stringify(updatedFavorites));
+      setIsFavorite(false);
+      alert(`${country.name.common} removed from favourites!`);
     }
   };
 
@@ -88,13 +101,15 @@ function OneCountry() {
     country.demonyms?.eng?.m || "N/A";
 
   return (
-    <div>
+    <div className="one-country-page">
+    <div className="country-header">
       <h1>{country.name.common}</h1>
       <img
         src={country.flags.png}
         alt={`${country.name.common} flag`}
-        style={{ width: "150px" }}
+        className="country-flag"
       />
+     <div className="country-details">
       <p><strong>Region:</strong> {country.region}</p>
       <p>🏛 <strong>Capital:</strong> {country.capital?.[0] || "N/A"}</p>
       <p>👥 <strong>Population:</strong> {country.population.toLocaleString()}</p>
@@ -104,14 +119,30 @@ function OneCountry() {
       <p>🌐 <strong>Country Code:</strong> {countryCode}</p>
       <p>🕒 <strong>Timezones:</strong> {timezones}</p>
       <p>👤 <strong>Demonym:</strong> {demonym}</p>
+      </div>
 
-      <button onClick={handleAddToFavourites}>❤️ Add to Favourites</button>
-
-      <button onClick={toggleReviews}>
-        {showReviews ? "Hide Reviews" : "Show Reviews"}
+     <div className="action-buttons">
+      <button 
+      onClick={handleAddToFavourites}
+      className={`action-button favorite-button ${isFavorite ? 'added'
+             : ''}`}>
+         {isFavorite ? '❤️ Remove from Favorite' : '❤️ Add to Favorites'}
       </button>
 
-      {showReviews && <Reviews countryName={country.name.common} />}
+      <button 
+      onClick={toggleReviews}
+      className="action-button review-button"
+      >
+        {showReviews ? "Hide Reviews" : "Show Reviews"}
+      </button>
+     </div>
+
+      {showReviews && (
+    <div>
+      <Reviews countryName={country.name.common} />
+    </div>
+  )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
# PR: Favorites Feature Implementation

## Description
Implemented the Favorites functionality including:
- Favorite button in OneCountry view with visual state feedback
- Favorites page displaying saved countries
- LocalStorage persistence
- Responsive design matching app's earthy aesthetic

## Changes Made

### 1. New Files
- `src/components/Favorites.jsx` - Favorites listing page
- `src/styles/favorites.css` - Favorites page styling

### 2. Modified Files
- `src/components/OneCountry.jsx`:
  - Added favorite state management
  - Implemented toggle button with visual feedback
  - Added localStorage integration
- `src/styles/oneCountry.css`:
  - Updated styles for favorite button states
  
### 3. Centering countries in the one country
- made the divs equal
![3be80f89-6edb-4f8c-9c21-76a6575f0c8a](https://github.com/user-attachments/assets/82cc87c0-0ea3-4c02-bd24-603d3a283493)
 
## Photos of what was implimented


![ebfaacaa-3f23-4dbd-aec6-dbf73caa3d19](https://github.com/user-attachments/assets/f7c836d2-f21f-45b1-a7aa-207e7acac81c)
![88be92bc-fd68-40ab-8621-d7a396300b89](https://github.com/user-attachments/assets/c771f1f5-33f3-4d51-9060-0ae6ccea5b10)
![5858507b-9fb9-4094-9b30-4bce1e34a08b](https://github.com/user-attachments/assets/07e56796-233d-4d06-966b-0872773d9713)
